### PR TITLE
Add ESP32 mqtt_if_add_reading_topic() and fix pbuf copy issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ mqtt_vpn -i <if_name> -a <ip> -b <broker> [-m <netmask>] [-n <clientid>] [-d]
 
 Requires the Paho MQTT C Client Library (https://www.eclipse.org/paho/files/mqttdoc/MQTTClient/html/index.html ) and the libnacl for the crypto operations.
 
+See mqttVPNdependencyInstaller.sh for help building/installing the libs. Just do `sudo chmod +x ./mqttVPNdependencyInstaller.sh` to enable it to execute. It will go all the way through and also run the make command to build the target executable "mqtt_vpn" which you then simply run as:
+`sudo ./mqtt_vpn`
+
 ## Future Issues
 - IPv6 as VPN
 

--- a/mqttVPNdependencyInstaller.sh
+++ b/mqttVPNdependencyInstaller.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+apt-get update
+apt-get install git
+sudo apt-get install build-essential gcc make cmake cmake-gui cmake-curses-gui
+sudo apt-get install libssl-dev
+sudo apt-get install doxygen graphviz
+sudo apt-get install libnacl-dev
+git clone https://github.com/martin-ger/MQTT_VPN.git
+cd ./MQTT_VPN
+git clone https://github.com/eclipse/paho.mqtt.c.git
+cd paho.mqtt.c
+git checkout v1.3.8
+cmake -Bbuild -H. -DPAHO_ENABLE_TESTING=OFF -DPAHO_BUILD_STATIC=ON \
+    -DPAHO_WITH_SSL=ON -DPAHO_HIGH_PERFORMANCE=ON
+sudo cmake --build build/ --target install
+sudo ldconfig
+cd ../
+make

--- a/mqtt_vpn_esp32/main/mqttif.c
+++ b/mqtt_vpn_esp32/main/mqttif.c
@@ -189,7 +189,7 @@ struct mqtt_if_data* mqtt_vpn_if_init(char *broker, char *user, char *broker_pas
     mqtt_if_set_password(mqtt_if, password);
 
     esp_event_loop_args_t loop_with_task_args = {
-        .queue_size = 5,
+        .queue_size = 50,
         .task_name = "loop_task", // task will be created
         .task_priority = uxTaskPriorityGet(NULL),
         .task_stack_size = 4096,

--- a/mqtt_vpn_esp32/main/mqttif.h
+++ b/mqtt_vpn_esp32/main/mqttif.h
@@ -1,13 +1,15 @@
 #ifndef __MQTT_IF_H__
 #define __MQTT_IF_H__
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <lwip/ip.h>
 
 #define MQTTIF_DIRECT_INPUT 0
 
 struct mqtt_if_data;
 
-struct mqtt_if_data *mqtt_vpn_if_init(char * broker, char* user, char* broker_password, char *topic_pre, char* password, ip4_addr_t ipaddr, ip4_addr_t netmask, ip4_addr_t gw);
+struct mqtt_if_data* mqtt_vpn_if_init(char* broker, char* user, char* broker_password, char* topic_pre, char* password, ip4_addr_t ipaddr, ip4_addr_t netmask, ip4_addr_t gw);
 
 void mqtt_if_del(struct mqtt_if_data *data);
 
@@ -25,5 +27,9 @@ void mqtt_if_set_flag(struct mqtt_if_data *data, int flag);
 void mqtt_if_clear_flag(struct mqtt_if_data *data, int flag);
 void mqtt_if_clear_dns(void);
 void mqtt_if_add_dns(uint32_t addr);
-
+void mqtt_if_add_reading_topic(struct mqtt_if_data *data, ip4_addr_t addr);
+void mqtt_if_flush_reading_topic(struct mqtt_if_data *data);
+#ifdef __cplusplus
+}
+#endif
 #endif


### PR DESCRIPTION
I wanted to be able to setup napt similar to the Arduino ESP8266 example so I added the same mqtt_if_add_reading_topic() concepts to the ESP32 file. I also found an error that when trying it without the encryption (for speed) it did not work at all because of this:
`pub_data->data_len = pbuf_copy_partial(p, pub_data->data_buf, sizeof(pub_data->data_buf), 0);`
It would only copy 4 bytes of the packet since 'sizeof(pub_data->data_buf)' was 4. I changed it to:
`pub_data->data_len = pbuf_copy_partial(p, pub_data->data_buf, 2048, 0);` and it worked fine from that point forward.

There's one standing issue where when I tried to access a particular png file over the vpn connection, it appears to just die and stop receiving the MQTT messages. I'm not sure if it just drops the connection or what. I enabled debugging and could never find the MQTT_EVENT_DISCONNECTED log coming through. Once it would silently stop receiving the messages, then nothing would work over the MQTT VPN (the ESP didn't crash, it kept running other things but the MQTT VPN just stopped working) until I restart the chip and then everything works fine again. Is there a way to check and re-initialize the MQTT connection periodically within this?