### PR TITLE
add wildcard reading topic, drop pkt on full queue

### DIFF
--- a/mqtt_vpn_esp32/main/mqttif.h
+++ b/mqtt_vpn_esp32/main/mqttif.h
@@ -5,7 +5,7 @@ extern "C" {
 #endif
 #include <lwip/ip.h>
 
-#define MQTTIF_DIRECT_INPUT 0
+#define MQTTIF_DIRECT_INPUT 1
 
 struct mqtt_if_data;
 
@@ -28,6 +28,7 @@ void mqtt_if_clear_flag(struct mqtt_if_data *data, int flag);
 void mqtt_if_clear_dns(void);
 void mqtt_if_add_dns(uint32_t addr);
 void mqtt_if_add_reading_topic(struct mqtt_if_data *data, ip4_addr_t addr);
+void mqtt_if_add_wildcard_reading_topic(struct mqtt_if_data *data);
 void mqtt_if_flush_reading_topic(struct mqtt_if_data *data);
 #ifdef __cplusplus
 }


### PR DESCRIPTION
made a few more changes. I added a function called mqtt_if_add_wildcard_reading_topic() that basically subscribes the mqtt client to pre_topic/# so that you can send an entire subnet to the ESP32 to NAT. I also put the esp_event_post_to timeout at 0 so that if the event queue is full then it just frees the packets for TCP retransmissions to kick in. Finally, I change to the MQTTIF_DIRECT_INPUT to skip the event queue for those packets. Then I decreased the queue_size to 33 (one more than the TCP TX buffer). I think that resolves the event loop getting blocked.

Also added subscribe() within the. add_topic methods so that if the users decides to add a topic later after initialization of the mqtt client, the subscribe will still happen.